### PR TITLE
Consolidate 2021 data

### DIFF
--- a/formula1_2021season_calendar.csv
+++ b/formula1_2021season_calendar.csv
@@ -1,12 +1,12 @@
 Round,Country,City,Circuit Name,GP Name,Race Date,First GP,Number of Laps,Circuit Length(km),Race Distance(km),Lap Record,Record Owner,Record Year,Turns,DRS Zones
 1,Bahrain,Sakhir,Bahrain International Circuit,Bahrain,28 Mar 2021,2004,57,5.412,308.238,1:31.447,Pedro de la Rosa,2005,15,3
 2,Italy,Imola,Autodromo Enzo e Dino Ferrari,Emilia Romagna,18 Apr 2021,1980,63,4.909,309.049,1:15.484,Lewis Hamilton,2020,19,1
-3,Portugal,Portimao,Autodromo Internacional do Algarve,Portugal,02 May 2021,2020,66,4.653,306.826,1:18.750,Lewis Hamilton,2020,15,1
+3,Portugal,Portimao,Autódromo Internacional do Algarve,Portugal,02 May 2021,2020,66,4.653,306.826,1:18.750,Lewis Hamilton,2020,15,1
 4,Spain,Catalunya,Circuit de Barcelona-Catalunya,Spain,09 May 2021,1991,66,4.675,308.424,1:18.149,Max Verstappen,2021,16,2
 5,Monaco,Monte Carlo,Circuit de Monaco,Monaco,23 May 2021,1950,78,3.337,260.286,1:12.909,Lewis Hamilton,2021,19,1
 6,Azerbaijan,Baku,Baku City Circuit,Azerbaijan,06 Jun 2021,2016,51,6.003,306.049,1:43.009,Charles Leclerc,2019,20,2
 7,France,Le Castellet,Circuit Paul Ricard,France,20 Jun 2021,1971,53,5.842,309.690,1:32.740,Sebastian Vettel,2019,15,2
-8,Austria,Spielberg,Red Bull Ring,Styria,04 Jul 2021,1970,71,4.318,306.452,1:05.619,Carlos Sainz,2020,10,3
+8,Austria,Spielberg,Red Bull Ring,Styria,27 Jun 2021,1970,71,4.318,306.452,1:05.619,Carlos Sainz,2020,10,3
 9,Austria,Spielberg,Red Bull Ring,Austria,18 Jul 2021,1970,71,4.318,306.452,1:05.619,Carlos Sainz,2020,10,3
 10,Great Britain,Siverstone,Silverstone Circuit,Great Britain,18 Jul 2021,1950,52,5.891,306.198,1:27.097,Max Verstappen,2020,18,2
 11,Hungary,Budapest,Hungaroring,Hungary,01 Aug 2021,1986,70,4.381,306.630,1:16:627,Lewis Hamilton,2020,14,1

--- a/formula1_2021season_raceResults.csv
+++ b/formula1_2021season_raceResults.csv
@@ -239,26 +239,26 @@ Belgium,17,9,Nikita Mazepin,Haas Ferrari,18,1,+31.993,0,No,N/A
 Belgium,18,7,Kimi Raikkönen,Alfa Romeo Racing Ferrari,20,1,+36.054,0,No,N/A
 Belgium,19,11,Sergio Perez,Red Bull Racing Honda,7,1,+38.205,0,No,N/A
 Belgium,20,18,Lance Stroll,Aston Martin Mercedes,19,1,+44.108,0,No,N/A
-Netherlands,1,33,Max Verstappen,Red Bull Racing Honda,1,72,1:30:05.395,25,No,1:13.275
-Netherlands,2,44,Lewis Hamilton,Mercedes,2,72,+20.932,19,Yes,1:11.097
-Netherlands,3,77,Valtteri Bottas,Mercedes,3,72,+56.460,15,No,1:12.549
-Netherlands,4,10,Pierre Gasly,AlphaTauri Honda,4,71,+1 lap,12,No,1:14.818
-Netherlands,5,16,Charles Leclerc,Ferrari,5,71,+1 lap,10,No,1:14.780
-Netherlands,6,14,Fernando Alonso,Alpine Renault,9,71,+1 lap,8,No,1:14.323
-Netherlands,7,55,Carlos Sainz,Ferrari,6,71,+1 lap,6,No,1:15.260
-Netherlands,8,11,Sergio Perez,Red Bull Racing Honda,20,71,+1 lap,4,No,1:13.461
-Netherlands,9,31,Esteban Ocon,Alpine Renault,8,71,+1 lap,2,No,1:14.675
-Netherlands,10,4,Lando Norris,McLaren Mercedes,13,71,+1 lap,1,No,1:14.236
-Netherlands,11,3,Daniel Ricciardo,McLaren Mercedes,10,71,+1 lap,0,No,1:14.920
-Netherlands,12,18,Lance Stroll,Aston Martin Mercedes,12,70,+2 laps,0,No,1:15.611
-Netherlands,13,5,Sebastian Vettel,Aston Martin Mercedes,15,70,+2 laps,0,No,1:13.958
-Netherlands,14,99,Antonio Giovinazzi,Alfa Romeo Racing Ferrari,7,70,+2 laps,0,No,1:15.125
-Netherlands,15,88,Robert Kubica,Alfa Romeo Racing Ferrari,16,70,+2 laps,0,No,1:15.442
-Netherlands,16,6,Nicholas Latifi,Williams Mercedes,19,70,+2 laps,0,No,1:15.790
-Netherlands,17,63,George Russell,Williams Mercedes,11,69,DNF,0,No,1:15.628
-Netherlands,18,47,Mick Schumacher,Haas Ferrari,17,69,+3 laps,0,No,1:15.927
-Netherlands,NC,22,Yuki Tsunoda,AlphaTauri Honda,14,48,DNF,0,No,1:15.783
-Netherlands,NC,9,Nikita Mazepin,Haas Ferrari,18,41,DNF,0,No,1:16.066
+Dutch,1,33,Max Verstappen,Red Bull Racing Honda,1,72,1:30:05.395,25,No,1:13.275
+Dutch,2,44,Lewis Hamilton,Mercedes,2,72,+20.932,19,Yes,1:11.097
+Dutch,3,77,Valtteri Bottas,Mercedes,3,72,+56.460,15,No,1:12.549
+Dutch,4,10,Pierre Gasly,AlphaTauri Honda,4,71,+1 lap,12,No,1:14.818
+Dutch,5,16,Charles Leclerc,Ferrari,5,71,+1 lap,10,No,1:14.780
+Dutch,6,14,Fernando Alonso,Alpine Renault,9,71,+1 lap,8,No,1:14.323
+Dutch,7,55,Carlos Sainz,Ferrari,6,71,+1 lap,6,No,1:15.260
+Dutch,8,11,Sergio Perez,Red Bull Racing Honda,20,71,+1 lap,4,No,1:13.461
+Dutch,9,31,Esteban Ocon,Alpine Renault,8,71,+1 lap,2,No,1:14.675
+Dutch,10,4,Lando Norris,McLaren Mercedes,13,71,+1 lap,1,No,1:14.236
+Dutch,11,3,Daniel Ricciardo,McLaren Mercedes,10,71,+1 lap,0,No,1:14.920
+Dutch,12,18,Lance Stroll,Aston Martin Mercedes,12,70,+2 laps,0,No,1:15.611
+Dutch,13,5,Sebastian Vettel,Aston Martin Mercedes,15,70,+2 laps,0,No,1:13.958
+Dutch,14,99,Antonio Giovinazzi,Alfa Romeo Racing Ferrari,7,70,+2 laps,0,No,1:15.125
+Dutch,15,88,Robert Kubica,Alfa Romeo Racing Ferrari,16,70,+2 laps,0,No,1:15.442
+Dutch,16,6,Nicholas Latifi,Williams Mercedes,19,70,+2 laps,0,No,1:15.790
+Dutch,17,63,George Russell,Williams Mercedes,11,69,DNF,0,No,1:15.628
+Dutch,18,47,Mick Schumacher,Haas Ferrari,17,69,+3 laps,0,No,1:15.927
+Dutch,NC,22,Yuki Tsunoda,AlphaTauri Honda,14,48,DNF,0,No,1:15.783
+Dutch,NC,9,Nikita Mazepin,Haas Ferrari,18,41,DNF,0,No,1:16.066
 Italy,1,3,Daniel Ricciardo,McLaren Mercedes,2,53,1:21:54.365,26,Yes,1:24.812
 Italy,2,4,Lando Norris,McLaren Mercedes,3,53,+1.747,18,No,1:24.971
 Italy,3,77,Valtteri Bottas,Mercedes,19,53,+4.921,15,No,1:24.872
@@ -359,26 +359,26 @@ Mexico,17,6,Nicholas Latifi,Williams Mercedes,13,69,+2 laps,0,No,1:21.546
 Mexico,18,9,Nikita Mazepin,Haas Ferrari,15,68,+3 laps,0,No,1:21.402
 Mexico,NC,47,Mick Schumacher,Haas Ferrari,14,0,DNF,0,No,N/A
 Mexico,NC,22,Yuki Tsunoda,AlphaTauri Honda,17,0,DNF,0,No,N/A
-Brazil,1,44,Lewis Hamilton,Mercedes,10,71,1:32:22.851,25,No,1:11.982
-Brazil,2,33,Max Verstappen,Red Bull Racing Honda,2,71,+10.496,18,No,1:12.486
-Brazil,3,77,Valtteri Bottas,Mercedes,1,71,+13.576,15,No,1:12.526
-Brazil,4,11,Sergio Perez,Red Bull Racing Honda,4,71,+39.940,13,Yes,1:11.010
-Brazil,5,16,Charles Leclerc,Ferrari,6,71,+49.517,10,No,1:12.822
-Brazil,6,55,Carlos Sainz,Ferrari,3,71,+51.820,8,No,1:12.710
-Brazil,7,10,Pierre Gasly,AlphaTauri Honda,7,70,+1 lap,6,No,1:13.227
-Brazil,8,31,Esteban Ocon,Alpine Renault,8,70,+1 lap,4,No,1:14.430
-Brazil,9,14,Fernando Alonso,Alpine Renault,12,70,+1 lap,2,No,1:13.922
-Brazil,10,4,Lando Norris,McLaren Mercedes,5,70,+1 lap,1,No,1:13.761
-Brazil,11,5,Sebastian Vettel,Aston Martin Mercedes,9,70,+1 lap,0,No,1:13.634
-Brazil,12,7,Kimi Raikkönen,Alfa Romeo Racing Ferrari,20,70,+1 lap,0,No,1:12.621
-Brazil,13,63,George Russell,Williams Mercedes,17,70,+1 lap,0,No,1:14.355
-Brazil,14,99,Antonio Giovinazzi,Alfa Romeo Racing Ferrari,13,70,+1 lap,0,No,1:14.227
-Brazil,15,22,Yuki Tsunoda,AlphaTauri Honda,15,70,+1 lap,0,No,1:14.204
-Brazil,16,6,Nicholas Latifi,Williams Mercedes,16,70,+1 lap,0,No,1:14.616
-Brazil,17,9,Nikita Mazepin,Haas Ferrari,19,69,+2 laps,0,No,1:14.954
-Brazil,18,47,Mick Schumacher,Haas Ferrari,18,69,+2 laps,0,No,1:13.793
-Brazil,NC,3,Daniel Ricciardo,McLaren Mercedes,11,49,DNF,0,No,1:14.443
-Brazil,NC,18,Lance Stroll,Aston Martin Mercedes,14,47,DNF,0,No,1:15.344
+Sao Paulo,1,44,Lewis Hamilton,Mercedes,10,71,1:32:22.851,25,No,1:11.982
+Sao Paulo,2,33,Max Verstappen,Red Bull Racing Honda,2,71,+10.496,18,No,1:12.486
+Sao Paulo,3,77,Valtteri Bottas,Mercedes,1,71,+13.576,15,No,1:12.526
+Sao Paulo,4,11,Sergio Perez,Red Bull Racing Honda,4,71,+39.940,13,Yes,1:11.010
+Sao Paulo,5,16,Charles Leclerc,Ferrari,6,71,+49.517,10,No,1:12.822
+Sao Paulo,6,55,Carlos Sainz,Ferrari,3,71,+51.820,8,No,1:12.710
+Sao Paulo,7,10,Pierre Gasly,AlphaTauri Honda,7,70,+1 lap,6,No,1:13.227
+Sao Paulo,8,31,Esteban Ocon,Alpine Renault,8,70,+1 lap,4,No,1:14.430
+Sao Paulo,9,14,Fernando Alonso,Alpine Renault,12,70,+1 lap,2,No,1:13.922
+Sao Paulo,10,4,Lando Norris,McLaren Mercedes,5,70,+1 lap,1,No,1:13.761
+Sao Paulo,11,5,Sebastian Vettel,Aston Martin Mercedes,9,70,+1 lap,0,No,1:13.634
+Sao Paulo,12,7,Kimi Raikkönen,Alfa Romeo Racing Ferrari,20,70,+1 lap,0,No,1:12.621
+Sao Paulo,13,63,George Russell,Williams Mercedes,17,70,+1 lap,0,No,1:14.355
+Sao Paulo,14,99,Antonio Giovinazzi,Alfa Romeo Racing Ferrari,13,70,+1 lap,0,No,1:14.227
+Sao Paulo,15,22,Yuki Tsunoda,AlphaTauri Honda,15,70,+1 lap,0,No,1:14.204
+Sao Paulo,16,6,Nicholas Latifi,Williams Mercedes,16,70,+1 lap,0,No,1:14.616
+Sao Paulo,17,9,Nikita Mazepin,Haas Ferrari,19,69,+2 laps,0,No,1:14.954
+Sao Paulo,18,47,Mick Schumacher,Haas Ferrari,18,69,+2 laps,0,No,1:13.793
+Sao Paulo,NC,3,Daniel Ricciardo,McLaren Mercedes,11,49,DNF,0,No,1:14.443
+Sao Paulo,NC,18,Lance Stroll,Aston Martin Mercedes,14,47,DNF,0,No,1:15.344
 Qatar,1,44,Lewis Hamilton,Mercedes,1,57,1:24:28.471,25,No,1:25.084
 Qatar,2,33,Max Verstappen,Red Bull Racing Honda,7,57,+25.743,19,Yes,1:23.196
 Qatar,3,14,Fernando Alonso,Alpine Renault,3,57,+59.457,15,No,1:26.682


### PR DESCRIPTION
2021 calendar: corrected Styria's race date and added newline;
2021 results: renamed Brazil->Sao Paulo and Netherlands->Dutch to make the 2 files link to each other correctly